### PR TITLE
Fixes #4 - Adding dagger function for civo cluster creation

### DIFF
--- a/civo-cluster/main.go
+++ b/civo-cluster/main.go
@@ -42,6 +42,33 @@ func (m *CivoCluster) ClusterShow(ctx context.Context,
 		Stdout(ctx)
 }
 
+// example usage: "dagger call cluster-create --api-token <env var name> --region <region> --name <cluster name> --node-count <node count> --node-size <node size> --version <cluster version>"
+func (m *CivoCluster) ClusterCreate(ctx context.Context,
+	apiToken *Secret,
+	// the region in which the new cluster should reside
+	region string,
+	// the name of the cluster
+	name string,
+	// +optional
+	// +default="3"
+	// the number of nodes to create (the master also acts as a node)
+	nodeCount string,
+	// +optional
+	// +default="g4s.kube.medium"
+	// the size of nodes to create. You can list available kubernetes sizes by civo size list -s kubernetes
+	nodeSize string,
+	// +optional
+	// +default="latest"
+	// the k3s version to use on the cluster. Defaults to the latest. Example - '--version 1.21.2+k3s1'
+	version string,
+) (string, error) {
+	c := civoContainer(apiToken)
+	return c.
+		WithEnvVariable("CACHE_BUSTER", time.Now().String()).
+		WithExec([]string{"k3s", "create", name, "--region", region, "--nodes", nodeCount, "--size", nodeSize, "--version", version, "--wait"}).
+		Stdout(ctx)
+}
+
 // example usage: "dagger call version"
 func (m *CivoCluster) Version(ctx context.Context) (string, error) {
 	c := civoContainer(nil)


### PR DESCRIPTION
Fixes #4 - Adding new dagger function that support civo cluster creation.

New function - **cluster-create**
<img width="1322" alt="image" src="https://github.com/user-attachments/assets/c9ba7096-3eee-4c28-87b3-ae99ee74dfd3">

Calling function with optional arguments
<img width="1322" alt="image" src="https://github.com/user-attachments/assets/b85a9466-a95c-4553-b9d1-576ce876be0c">

Calling function without optional arguments
<img width="1310" alt="image" src="https://github.com/user-attachments/assets/8d0eaf81-a62b-4c9f-804f-067c80ee93fb">
